### PR TITLE
Remove debugger-command in message-frame parser

### DIFF
--- a/application/client.plugins.standalone/parsers.messageframes/src/parser.ts
+++ b/application/client.plugins.standalone/parsers.messageframes/src/parser.ts
@@ -549,7 +549,6 @@ export class MessageFrameParsing extends Toolkit.ASelectionParser {
     }
 
     public getParserName(str: string): string | undefined {
-        debugger
         return isParsable(str) ? "Parse as MessageFrame" : undefined;
     }
 }


### PR DESCRIPTION
There was a left-over debugger-command in getParserName() of the message-frame plugin, which would automatically launch the debugger, whenever the conext-menu on a selection is triggered.