### PR TITLE
Fix display of ANSI-colors

### DIFF
--- a/application/client.plugins.standalone/row.parser.ascii/package.json
+++ b/application/client.plugins.standalone/row.parser.ascii/package.json
@@ -19,7 +19,8 @@
     "ts-loader": "^5.2.2",
     "typescript": "^3.1.3",
     "webpack": "^4.23.1",
-    "webpack-cli": "^3.1.2"
+    "webpack-cli": "^3.1.2",
+    "ansi_up": "^4.0.4"
   },
   "dependencies": {
     "logviewer.client.toolkit": "0.0.62"

--- a/application/client.plugins.standalone/row.parser.ascii/src/parser.ts
+++ b/application/client.plugins.standalone/row.parser.ascii/src/parser.ts
@@ -1,69 +1,36 @@
 // tslint:disable:object-literal-sort-keys
 import * as Toolkit from 'logviewer.client.toolkit';
+import { default as AnsiUp } from 'ansi_up';
 
-const STYLES: { [key: string]: string } = {
-    1   : 'font-weight: bold;',
-    3   : 'font-style: italic;',
-    4   : 'text-decoration: underline;',
-    30  : 'color: black;',
-    31  : 'color: red;',
-    32  : 'color: green;',
-    33  : 'color: yellow;',
-    34  : 'color: blue;',
-    35  : 'color: magenta;',
-    36  : 'color: cyan;',
-    37  : 'color: white;',
-    40  : 'background-color: black;',
-    41  : 'background-color: red;',
-    42  : 'background-color: green;',
-    43  : 'background-color: yellow;',
-    44  : 'background-color: blue;',
-    45  : 'background-color: magenta;',
-    46  : 'background-color: cyan;',
-    47  : 'background-color: white;',
-};
-
-const CBlockedStyles: { [key: string]: number[] } = {
-    [Toolkit.EThemeType.dark]: [30, 47],
-    [Toolkit.EThemeType.light]: [37, 40],
-    [Toolkit.EThemeType.undefined]: [],
-};
+const ansi_up = new AnsiUp();
+ansi_up.escape_for_html = false;
 
 const REGS = {
-    COLORS          : /\033\[[\d;]{1,}m[^\033]*/g,
-    COLORS_VALUE    : /\033\[.*?m/g,
-    CLEAR_COLORS    : /[\033\[m]/g,
-    BEGIN           : /^[^\033]*/g,
+    COLORS: /\x1b\[[\d;]{1,}[mG]/,
+    COLORS_GLOBAL: /\x1b\[[\d;]{1,}[mG]/g,
 };
+
+const ignoreList: { [key: string]: boolean } = {};
 
 export class ASCIIColorsParser extends Toolkit.ARowCommonParser {
 
     public parse(str: string, themeTypeRef: Toolkit.EThemeType, row: Toolkit.IRowInfo): string {
-        const themeType: number[] | undefined = CBlockedStyles[themeTypeRef] === undefined ? [] : CBlockedStyles[themeTypeRef];
-        const parts: RegExpMatchArray | null = str.match(REGS.COLORS);
-        if (parts instanceof Array && parts.length > 1) {
-            const _begin: RegExpMatchArray | null = str.match(REGS.BEGIN);
-            let result: string = _begin instanceof Array ? (_begin.length > 0 ? _begin[0] : '') : '';
-            parts.forEach((part: string) => {
-                const values: RegExpMatchArray | null = part.match(REGS.COLORS_VALUE);
-                const value: string | null = values instanceof Array ? (values.length === 1 ? values[0].replace(REGS.CLEAR_COLORS, '') : null) : null;
-                let text: string = part.replace(REGS.COLORS_VALUE, '');
-                let inlineStyle: string = '';
-                if (value !== null) {
-                    value.split(';').forEach((def: string) => {
-                        const num: number = parseInt(def, 10);
-                        if (themeType.indexOf(num) !== -1) {
-                            return;
-                        }
-                        STYLES[def] !== void 0 && (inlineStyle += ' ' + STYLES[def]);
-                    });
-                    text = inlineStyle !== '' ? ('<span class="noreset" style="' + inlineStyle + '">' + text + '</span>') : text;
+        if (typeof row.sourceName === "string") {
+            if (ignoreList[row.sourceName] === undefined) {
+                ignoreList[row.sourceName] = row.sourceName.search(/\.dlt$/gi) !== -1;
+            }
+
+            if (!ignoreList[row.sourceName]) {
+                if (row.hasOwnStyles) {
+                    // Only strip ANSI escape-codes
+                    return str.replace(REGS.COLORS_GLOBAL, "");
+                } else if (REGS.COLORS.test(str)) {
+                    // ANSI escape-codes to html color-styles
+                    return ansi_up.ansi_to_html(str);
                 }
-                result = result + text;
-            });
-            return result;
+            }
         }
+
         return str;
     }
-
 }

--- a/application/sandbox/row.parser.ascii/render/package.json
+++ b/application/sandbox/row.parser.ascii/render/package.json
@@ -19,7 +19,8 @@
     "ts-loader": "^5.2.2",
     "typescript": "^3.1.3",
     "webpack": "^4.23.1",
-    "webpack-cli": "^3.1.2"
+    "webpack-cli": "^3.1.2",
+    "ansi_up": "^4.0.4"
   },
   "dependencies": {
     "logviewer.client.toolkit": "0.0.62"


### PR DESCRIPTION
This will fix the display of colors encoded as ANSI escape-sequence.
It can also be made aware of custom styles in the row and thus only strip the escape-sequence.